### PR TITLE
Update liveness and readiness probe configurations in values.yaml

### DIFF
--- a/charts/default/values.yaml
+++ b/charts/default/values.yaml
@@ -282,12 +282,12 @@ nomad:
     podLabels: {}
     livenessProbe:
       initialDelaySeconds: 90
-      periodSeconds: 10
-      timeoutSeconds: 70
+      periodSeconds: 15
+      timeoutSeconds: 10
     readinessProbe:
       initialDelaySeconds: 90
-      periodSeconds: 3
-      timeoutSeconds: 63
+      periodSeconds: 10
+      timeoutSeconds: 5
 
   app:
     replicaCount: 1


### PR DESCRIPTION
 the originals had timeoutSeconds greater than periodSeconds (63 > 3, 70 > 10). Plain k8s/nginx tolerates that, but GKE derives the GCE load-balancer health check from the probe (timeoutSeconds→timeoutSec, periodSeconds→checkIntervalSec) and GCP rejects timeoutSec ≥ checkIntervalSec with Error 400. Now timeout < period on both.