### PR TITLE
Changed number of gunicorn workers to 1.

### DIFF
--- a/charts/default/templates/app/deployment.yaml
+++ b/charts/default/templates/app/deployment.yaml
@@ -175,7 +175,7 @@ spec:
                   name: {{ include "nomad.secretName.north" . }}
                   key: {{ .Values.nomad.secrets.north.hubServiceApiToken.key }}
             {{- end }}
-          command: ["python", "-m", "nomad.cli", "admin", "run", "app", "--log-config", "/app/uvicorn.log.conf", "--with-gui", "--host", "0.0.0.0"]
+          command: ["python", "-m", "nomad.cli", "admin", "run", "app", "--log-config", "/app/uvicorn.log.conf", "--workers=1", "--with-gui", "--host", "0.0.0.0"]
       volumes:
         {{- with .Values.nomad.volumes }}
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
The default number of workers is 4, which makes the `app` pod very heavy (e.g. 10 GB or RAM). The scaling of the app should be handled instead by kubernetes through replicas.

We have now tested this same change on our production, and the same change will be applied to the docker-compose setup.