### PR TITLE
add helm test hook for end-to-end deployment verification

### DIFF
--- a/charts/default/Chart.yaml
+++ b/charts/default/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.5.0
+version: 1.4.4
 
 # NOMAD application version being deployed
 appVersion: "1.4.2"

--- a/charts/default/Chart.yaml
+++ b/charts/default/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.4.3
+version: 1.5.0
 
 # NOMAD application version being deployed
 appVersion: "1.4.2"

--- a/charts/default/README.md
+++ b/charts/default/README.md
@@ -687,6 +687,203 @@ docker exec nomad-oasis-control-plane chown -R 1000:1000 /app/.volumes/fs/north
 docker exec nomad-oasis-control-plane chmod -R 755 /app/.volumes/fs/north
 ```
 
+## Verifying the Deployment (`helm test`)
+
+Healthy pods only prove the processes started — the readiness/liveness probes check that the API answers HTTP, not that data actually flows through parsing, the worker, Temporal, MongoDB and Elasticsearch. A broken plugin in a custom image is the classic trap: every pod is green, but uploads never produce entries.
+
+The chart ships a `helm test` hook that exercises the real pipeline. It is **disabled by default** — enable it per deployment with `nomad.tests.enabled: true` (or `--set nomad.tests.enabled=true`), then run:
+
+```bash
+helm test <release-name> --namespace <namespace> --logs
+```
+
+It runs as a Pod (reusing `nomad.image`, so no extra pull and the same `imagePullSecrets`) that drives the public API **through the proxy** — no ingress, LoadBalancer or cloud-specific setup required, so it behaves identically on EKS, GKE, minikube and Kind. There are two tiers:
+
+**Tier 1 — component & plugin health (always on, no credentials).** Asserts that the app answers via the proxy, that parsers **and** normalizers are loaded (proving your custom image's plugins registered), and that Elasticsearch responds.
+
+**Tier 2 — full end-to-end (opt-in).** Logs in, uploads a file, waits for processing, asserts the entry is created, searchable, and produced by the expected parser, then deletes the upload and confirms the entries **and** files are gone. This is the only check that proves app → Temporal → worker → Mongo → shared `fs` volumes all work together.
+
+### Configuration (`nomad.tests`)
+
+```yaml
+nomad:
+  tests:
+    enabled: false             # opt in per deployment to render the helm test hook
+    expect:                    # per-plugin-type presence checks; empty list = skip that type
+      parsers: []              # Tier 1: names from GET /info parsers[]
+      normalizers: []          # Tier 1: names from GET /info normalizers[]
+      pluginPackages: []       # Tier 1: names from GET /info plugin_packages[] (any type)
+      apps: []                 # Tier 1: app id/path from GET /api/v1/apps/entry-points
+      apis: []                 # Tier 1: API entry point prefixes (mounted FastAPI)
+      dashboards: []           # Tier 1: dashboard id (mounted at <base>/dashboards/<id>)
+      actions: []              # Tier 2: action_id from /api/v1/actions/schemas (needs creds)
+    upload:
+      enabled: false           # Tier 2: needs credentials, off by default
+      credentialsSecret: ""    # Secret with a `token` key (recommended) OR `username`+`password`
+      timeout: 300             # seconds to wait for processing (and cleanup)
+      sampleFileName: test.archive.json
+      sampleFileContent: |     # inline text sample (ignored when an existingSample* is set)
+        { "metadata": { "entry_name": "nomad-helm-test" } }
+      existingSampleConfigMap: ""  # mount a user-created ConfigMap for binary samples (e.g. .zip)
+      existingSampleSecret: ""     # ...or a Secret (takes precedence) for sensitive samples
+      expectParserName: ""     # assert the entry was produced by THIS parser (proves a plugin ran)
+      expectEntryType: ""      # optionally assert the resulting entry_type
+```
+
+### Plugin-type coverage
+
+NOMAD plugins come in several entry-point types. Each is loaded independently, so a plugin package can be installed while one of its entry points fails to register — `helm test` verifies each type against the API surface that actually exposes it:
+
+| Plugin type | How it's verified | Endpoint | Tier |
+|-------------|-------------------|----------|------|
+| Parser | registered + (optionally) **executed** on an upload | `GET /info` `parsers[]`; `expectParserName` after processing | 1 (+2) |
+| Normalizer | registered | `GET /info` `normalizers[]` | 1 |
+| Schema package | package installed / `entry_type` on a produced entry | `GET /info` `plugin_packages[]`; `expectEntryType` | 1 (+2) |
+| App (GUI search app) | loaded | `GET /api/v1/apps/entry-points` | 1 |
+| API | FastAPI mounted (its `openapi.json` responds) | `GET <base>/<prefix>/openapi.json` | 1 |
+| Dashboard | mounted | `GET <base>/dashboards/<id>` | 1 |
+| Action | loaded (login required) | `GET /api/v1/actions/schemas` | 2 |
+
+> [!NOTE]
+> `expect.pluginPackages` is the catch-all: `/info` lists every installed plugin package regardless of type, so it confirms a package is present even for a type not individually listed above. The per-type checks go further by proving the *entry point* mounted, not just that the package is on disk. All checks are opt-in — an empty list skips that type.
+
+> [!IMPORTANT]
+> `expect.parsers` uses the **bare** parser name as returned by `/info` — the `parsers/` prefix is stripped there (e.g. `crystal`, `fhi-aims`, not `parsers/crystal`). In contrast, `upload.expectParserName` matches the entry's stored `parser_name`, which **keeps** the prefix (e.g. `parsers/vasp`).
+
+Example covering every type of a custom image:
+
+```yaml
+nomad:
+  tests:
+    expect:
+      parsers: ["my_parser"]          # bare name as listed by /info (no "parsers/" prefix)
+      normalizers: ["MyNormalizer"]
+      pluginPackages: ["my-nomad-plugin"]
+      apps: ["my_plugin.apps.mysearchapp"]
+      apis: ["my-api"]
+      dashboards: ["my-dashboard"]
+      actions: ["my_action"]          # verified only when upload.enabled + credentials
+    upload:
+      enabled: true
+      credentialsSecret: nomad-test-creds
+```
+
+### Authentication for Tier 2
+
+The upload flow needs a NOMAD account. Provide **either** a pre-created app token (recommended — portable, and works even where the Keycloak realm disables the password grant) **or** a username/password:
+
+```bash
+# Recommended: an app token created from the NOMAD GUI (user settings)
+kubectl create secret generic nomad-test-creds --from-literal=token=<app-token>
+
+# Or username + password
+kubectl create secret generic nomad-test-creds \
+  --from-literal=username=<user> --from-literal=password=<pass>
+```
+```yaml
+nomad:
+  tests:
+    upload:
+      enabled: true
+      credentialsSecret: nomad-test-creds
+```
+
+### Testing a custom plugin
+
+To prove a custom parser actually **ran** (not just that it registered), upload a file it matches and assert its `parser_name`:
+
+```yaml
+nomad:
+  tests:
+    expect:
+      pluginPackages: ["my-plugin-package"]  # Tier 1: present in the image
+    upload:
+      enabled: true
+      credentialsSecret: nomad-test-creds
+      sampleFileName: my_data.dat          # a file your parser matches
+      sampleFileContent: |
+        ...raw content...
+      expectParserName: "parsers/my_plugin"  # Tier 2: proves it executed
+```
+
+### Uploading a local `.zip`
+
+NOMAD auto-extracts `.zip`/`.tar` on upload (one entry per mainfile). A binary zip can't be inlined in `values.yaml` (ConfigMaps are text and cap at ~1 MiB), so create a ConfigMap from your local file and reference it:
+
+```bash
+kubectl create configmap nomad-test-sample \
+  --from-file=sample.zip=./sample.zip -n <namespace>
+```
+```yaml
+nomad:
+  tests:
+    upload:
+      enabled: true
+      credentialsSecret: nomad-test-creds
+      sampleFileName: sample.zip           # key inside the ConfigMap must match
+      existingSampleConfigMap: nomad-test-sample
+      expectParserName: "parsers/vasp"      # optional
+```
+
+> [!NOTE]
+> ConfigMaps/Secrets cap at ~1 MiB. For larger fixtures, use a pre-populated PVC instead.
+
+### Using `helm test` in CI/CD
+
+`helm test` exits non-zero if any check fails, so it plugs straight into a pipeline as the "is the deployment green?" gate. The pattern is: install/upgrade → wait for rollout → run the test → surface logs.
+
+```bash
+set -euo pipefail
+
+helm upgrade --install nomad-oasis ./charts/default \
+  -f my-values.yaml --namespace nomad --create-namespace --wait --timeout 15m \
+  --set nomad.tests.enabled=true
+
+# Optional but recommended: ensure every Deployment finished rolling out
+kubectl -n nomad rollout status deploy --timeout=10m
+
+# The gate. Non-zero exit fails the job; --logs prints the per-check PASS/FAIL.
+helm test nomad-oasis --namespace nomad --logs
+```
+
+For **GitHub Actions**, credentials for Tier 2 go through repository secrets:
+
+```yaml
+# .github/workflows/verify.yml (excerpt)
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # ... set up kubectl/helm and cluster access ...
+      - name: Provision Tier 2 credentials
+        run: |
+          kubectl -n nomad create secret generic nomad-test-creds \
+            --from-literal=token='${{ secrets.NOMAD_APP_TOKEN }}' \
+            --dry-run=client -o yaml | kubectl apply -f -
+      - name: Deploy
+        run: |
+          helm upgrade --install nomad-oasis ./charts/default \
+            -f my-values.yaml -n nomad --create-namespace --wait --timeout 15m \
+            --set nomad.tests.enabled=true \
+            --set nomad.tests.upload.enabled=true \
+            --set nomad.tests.upload.credentialsSecret=nomad-test-creds
+      - name: Verify deployment (gate)
+        run: helm test nomad-oasis -n nomad --logs
+      - name: Dump diagnostics on failure
+        if: failure()
+        run: |
+          kubectl -n nomad get pods
+          kubectl -n nomad logs -l app.kubernetes.io/component=test --tail=-1 || true
+```
+
+Notes for CI:
+
+- **Prefer an app token over a password** for `credentialsSecret` — it's a single revocable secret and doesn't depend on the Keycloak realm allowing the password grant.
+- On a locked-down runner with no internet egress, Tier 1 still runs fully in-cluster; only Tier 2 login needs to reach Keycloak. Keep Tier 2 off in that case (`upload.enabled: false`) and rely on the plugin-entry-point checks.
+- The test Pod is left in place after a run (recreated on the next `helm test`), so `kubectl logs -l app.kubernetes.io/component=test` retrieves the result for build artifacts even after the command returns.
+- For a scheduled health check of a long-running deployment, run `helm test` on a cron (e.g. a `CronJob` or a scheduled workflow) and alert on non-zero exit.
+
 ## Troubleshooting
 
 ### Pods not starting

--- a/charts/default/templates/NOTES.txt
+++ b/charts/default/templates/NOTES.txt
@@ -32,6 +32,19 @@
    exist before certificates will be issued. See custom-values/tls.yaml for examples.
 {{- end }}
 
+{{- if .Values.nomad.tests.enabled }}
+
+✅ Verify the deployment actually processes data (not just that pods are Ready):
+
+     helm test {{ .Release.Name }} --namespace {{ .Release.Namespace }} --logs
+
+   This checks the app/proxy, that parsers + normalizers (incl. your custom image's
+   plugins) loaded, and that Elasticsearch responds. To also exercise a real
+   upload -> Temporal -> worker -> entry flow, set nomad.tests.upload.enabled=true
+   and point nomad.tests.upload.credentialsSecret at a Secret with `username` and
+   `password` keys.
+{{- end }}
+
 1. Get the application URL by running these commands:
 {{- if .Values.nomad.ingress.enabled }}
   http{{ if $tlsEnabled }}s{{ end }}://{{ $apiHost }}{{ $path }}

--- a/charts/default/templates/tests/test-pipeline.yaml
+++ b/charts/default/templates/tests/test-pipeline.yaml
@@ -1,0 +1,327 @@
+{{- if and .Values.nomad.enabled .Values.nomad.tests.enabled -}}
+{{- $config := .Values.nomad.config -}}
+{{- $tests := .Values.nomad.tests -}}
+{{- $image := $tests.image | default .Values.nomad.image -}}
+{{- $appBase := printf "http://%s-proxy:%v%s" (include "nomad.fullname" .) .Values.nomad.proxy.service.port $config.services.api_base_path -}}
+{{- $apiBase := printf "%s/api/v1" $appBase -}}
+{{- $extSample := or $tests.upload.existingSampleSecret $tests.upload.existingSampleConfigMap -}}
+{{- $samplePath := ternary (printf "/sample/%s" $tests.upload.sampleFileName) (printf "/scripts/%s" $tests.upload.sampleFileName) (not (not $extSample)) -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "nomad.fullname" . }}-test
+  labels:
+    {{- include "nomad.labels" . | nindent 4 }}
+    app.kubernetes.io/component: test
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+data:
+  {{- if not $extSample }}
+  # A minimal NOMAD archive. The archive parser (parsers/archive) matches any
+  # *archive.json file and, with only a `metadata` block, produces a valid empty
+  # entry that always processes to SUCCESS on a vanilla distro. For a binary
+  # sample (e.g. a local .zip), set nomad.tests.upload.existingSampleConfigMap
+  # or existingSampleSecret instead of this inline content.
+  {{ $tests.upload.sampleFileName }}: |
+{{ $tests.upload.sampleFileContent | indent 4 }}
+  {{- end }}
+  run-tests.py: |
+    import os, sys, json, time, urllib.request, urllib.error, urllib.parse
+
+    API = os.environ["API_BASE"].rstrip("/")
+    APP = os.environ["APP_BASE"].rstrip("/")
+    fails = []
+
+    def req(method, path, data=None, headers=None, token=None, base=None):
+        h = dict(headers or {})
+        if token:
+            h["Authorization"] = "Bearer " + token
+        r = urllib.request.Request((base or API) + path, data=data, method=method, headers=h)
+        try:
+            resp = urllib.request.urlopen(r, timeout=30)
+            body = resp.read()
+            return resp.status, (json.loads(body) if body else {})
+        except urllib.error.HTTPError as e:
+            body = e.read()
+            try:
+                return e.code, json.loads(body)
+            except Exception:
+                return e.code, {"raw": body.decode(errors="replace")[:300]}
+        except Exception as e:
+            return 0, {"error": str(e)}
+
+    def env_list(name):
+        return [x for x in os.environ.get(name, "").split(",") if x]
+
+    def check(cond, msg):
+        print(("  PASS  " if cond else "  FAIL  ") + msg, flush=True)
+        if not cond:
+            fails.append(msg)
+
+    print("Target API: " + API, flush=True)
+    print("== Tier 1: component & plugin-entry-point health (no credentials) ==", flush=True)
+    st, info = req("GET", "/info")
+    check(st == 200, "GET /info -> %s (app reachable via proxy)" % st)
+    parsers = info.get("parsers", []) or []
+    normalizers = info.get("normalizers", []) or []
+    pkgs = [p.get("name") for p in (info.get("plugin_packages") or [])]
+    check(len(parsers) > 0, "parsers loaded (%d)" % len(parsers))
+    check(len(normalizers) > 0, "normalizers loaded (%d)" % len(normalizers))
+    for want in env_list("EXPECT_PARSERS"):
+        check(want in parsers, "parser entry point loaded: %s" % want)
+    for want in env_list("EXPECT_NORMALIZERS"):
+        check(want in normalizers, "normalizer entry point loaded: %s" % want)
+    for want in env_list("EXPECT_PLUGINS"):
+        check(want in pkgs, "plugin package installed: %s" % want)
+
+    st, _ = req("GET", "/entries?page_size=1")
+    check(st == 200, "GET /entries -> %s (Elasticsearch reachable)" % st)
+
+    # App entry points (GUI search apps) — anonymous read is allowed by default.
+    want_apps = env_list("EXPECT_APPS")
+    if want_apps:
+        st, resp = req("GET", "/apps/entry-points")
+        ids = set()
+        for a in (resp.get("data") or []):
+            ids.add(a.get("id"))
+            ids.add(a.get("path"))
+        check(st == 200, "GET /apps/entry-points -> %s" % st)
+        for want in want_apps:
+            check(want in ids, "app entry point loaded: %s" % want)
+
+    # API entry points — each mounts a FastAPI at <app_base>/<prefix>; its
+    # /openapi.json is served iff the entry point mounted successfully.
+    for prefix in env_list("EXPECT_APIS"):
+        st, _ = req("GET", "/%s/openapi.json" % prefix.strip("/"), base=APP)
+        check(st == 200, "api entry point mounted: %s (openapi.json -> %s)" % (prefix, st))
+
+    # Dashboard entry points — mounted at <app_base>/dashboards/<id_url_safe>.
+    for did in env_list("EXPECT_DASHBOARDS"):
+        st, _ = req("GET", "/dashboards/%s" % did.strip("/"), base=APP)
+        check(st != 404 and st != 0, "dashboard entry point mounted: %s (-> %s)" % (did, st))
+
+    if env_list("EXPECT_ACTIONS") and os.environ.get("UPLOAD_ENABLED") != "true":
+        print("  NOTE  expect.actions is set but Tier 2 is off (needs credentials); "
+              "action entry points were NOT verified.", flush=True)
+
+    if os.environ.get("UPLOAD_ENABLED") == "true":
+        print("== Tier 2: end-to-end login -> upload -> process -> search -> delete ==", flush=True)
+        timeout = int(os.environ.get("TIMEOUT", "300"))
+        # Auth: prefer a pre-created NOMAD app token (portable, no ROPC grant
+        # needed); fall back to username/password (ROPC via /auth/token).
+        token = os.environ.get("NOMAD_TOKEN") or None
+        if token:
+            check(True, "using pre-created app token")
+        else:
+            user = os.environ.get("NOMAD_USERNAME")
+            pw = os.environ.get("NOMAD_PASSWORD")
+            check(bool(user and pw), "credentials provided (token, or username+password)")
+            if user and pw:
+                form = urllib.parse.urlencode({"username": user, "password": pw}).encode()
+                st, tok = req("POST", "/auth/token", data=form,
+                              headers={"Content-Type": "application/x-www-form-urlencoded"})
+                check(st == 200, "POST /auth/token (login) -> %s" % st)
+                token = tok.get("access_token")
+                check(bool(token), "received access token")
+
+        if token:
+            # Action entry points — /actions/schemas requires a logged-in user,
+            # so this check lives in Tier 2 rather than Tier 1.
+            want_actions = env_list("EXPECT_ACTIONS")
+            if want_actions:
+                st, resp = req("GET", "/actions/schemas", token=token)
+                action_ids = set()
+                if isinstance(resp, list):
+                    action_ids = {a.get("action_id") for a in resp}
+                check(st == 200, "GET /actions/schemas -> %s" % st)
+                for want in want_actions:
+                    check(want in action_ids, "action entry point loaded: %s" % want)
+
+            expect_parser = os.environ.get("EXPECT_PARSER_NAME") or ""
+            expect_type = os.environ.get("EXPECT_ENTRY_TYPE") or ""
+            name = os.environ["SAMPLE_NAME"]
+            with open(os.environ["SAMPLE_PATH"], "rb") as f:
+                sample = f.read()
+            st, up = req("POST", "/uploads?" + urllib.parse.urlencode({"file_name": name}),
+                         data=sample, headers={"Content-Type": "application/octet-stream"},
+                         token=token)
+            check(st in (200, 201), "POST /uploads (file uploaded) -> %s" % st)
+            uid = (up.get("data") or {}).get("upload_id") or up.get("upload_id")
+            check(bool(uid), "upload created (id=%s)" % uid)
+            if uid:
+                # 1) Worker + Temporal: wait for processing to finish.
+                waited, running, status = 0, True, None
+                while waited < timeout:
+                    st, u = req("GET", "/uploads/%s" % uid, token=token)
+                    d = u.get("data") or {}
+                    running = d.get("process_running", True)
+                    status = d.get("process_status")
+                    if not running:
+                        break
+                    time.sleep(5)
+                    waited += 5
+                check(not running, "processing finished (waited %ss, status=%s)" % (waited, status))
+                check(status == "SUCCESS", "upload process_status == SUCCESS (got %s)" % status)
+
+                # 2) Mongo + ES: entries created, all SUCCESS, and indexed
+                #    (entry_metadata is populated from Elasticsearch).
+                st, ent = req("GET", "/uploads/%s/entries" % uid, token=token)
+                data = ent.get("data") or []
+                total = (ent.get("pagination") or {}).get("total", 0)
+                check(total > 0, "entries created by worker (%s)" % total)
+                # processing_failed covers ALL entries (pagination-proof) - a .zip
+                # of raw files typically yields many entries across several pages.
+                failed = ent.get("processing_failed")
+                check(failed == 0, "no failed entries (processing_failed=%s of %s)" % (failed, total))
+                metas = [e.get("entry_metadata") for e in data]
+                check(bool(metas) and all(m for m in metas),
+                      "entries indexed in Elasticsearch (entry_metadata present)")
+
+                # 3) Custom plugin actually RAN: the matching parser is yours,
+                #    not the generic archive parser. Opt-in via values.
+                parser_names = [e.get("parser_name") for e in data]
+                if expect_parser:
+                    check(expect_parser in parser_names,
+                          "custom parser ran: parser_name '%s' in %s" % (expect_parser, parser_names))
+                if expect_type:
+                    types = [(m or {}).get("entry_type") for m in metas]
+                    check(expect_type in types,
+                          "custom schema present: entry_type '%s' in %s" % (expect_type, types))
+
+                # 4) User-facing search: the entry is findable via the query API.
+                q = {"owner": "visible", "query": {"upload_id": uid},
+                     "pagination": {"page_size": 5}}
+                st, s = req("POST", "/entries/query", data=json.dumps(q).encode(),
+                            headers={"Content-Type": "application/json"}, token=token)
+                found = (s.get("pagination") or {}).get("total", 0)
+                check(st == 200 and found > 0,
+                      "entry searchable via /entries/query -> %s (%s hit(s))" % (st, found))
+
+                # 5) Cleanup: delete removes entries (Mongo + ES) AND raw/staging
+                #    files. Poll until the upload is gone to confirm it completed.
+                st, _ = req("DELETE", "/uploads/%s" % uid, token=token)
+                check(st in (200, 404), "DELETE /uploads/%s accepted -> %s" % (uid, st))
+                waited = 0
+                while waited < timeout:
+                    st, _ = req("GET", "/uploads/%s" % uid, token=token)
+                    if st == 404:
+                        break
+                    time.sleep(3)
+                    waited += 3
+                check(st == 404,
+                      "upload, entries and files removed (GET -> %s after %ss)" % (st, waited))
+
+    print("", flush=True)
+    if fails:
+        print("RESULT: FAILED (%d check(s))" % len(fails), flush=True)
+        for m in fails:
+            print("  - " + m, flush=True)
+        sys.exit(1)
+    print("RESULT: ALL CHECKS PASSED", flush=True)
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "nomad.fullname" . }}-test
+  labels:
+    {{- include "nomad.labels" . | nindent 4 }}
+    app.kubernetes.io/component: test
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-weight": "0"
+    # Keep the pod after a run so `kubectl logs` works; it is recreated on the
+    # next `helm test`. (No hook-succeeded, so a failed run's logs survive too.)
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  restartPolicy: Never
+  {{- with .Values.nomad.imagePullSecrets }}
+  imagePullSecrets:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  securityContext:
+    {{- toYaml .Values.nomad.app.podSecurityContext | nindent 4 }}
+  containers:
+    - name: test
+      image: "{{ $image.repository }}:{{ $image.tag }}"
+      imagePullPolicy: {{ $image.pullPolicy }}
+      securityContext:
+        {{- toYaml .Values.nomad.app.securityContext | nindent 8 }}
+      command: ["python3", "/scripts/run-tests.py"]
+      env:
+        - name: API_BASE
+          value: {{ $apiBase | quote }}
+        - name: APP_BASE
+          value: {{ $appBase | quote }}
+        - name: EXPECT_PARSERS
+          value: {{ join "," $tests.expect.parsers | quote }}
+        - name: EXPECT_NORMALIZERS
+          value: {{ join "," $tests.expect.normalizers | quote }}
+        - name: EXPECT_PLUGINS
+          value: {{ join "," $tests.expect.pluginPackages | quote }}
+        - name: EXPECT_APPS
+          value: {{ join "," $tests.expect.apps | quote }}
+        - name: EXPECT_APIS
+          value: {{ join "," $tests.expect.apis | quote }}
+        - name: EXPECT_DASHBOARDS
+          value: {{ join "," $tests.expect.dashboards | quote }}
+        - name: EXPECT_ACTIONS
+          value: {{ join "," $tests.expect.actions | quote }}
+        - name: UPLOAD_ENABLED
+          value: {{ $tests.upload.enabled | quote }}
+        - name: TIMEOUT
+          value: {{ $tests.upload.timeout | quote }}
+        - name: SAMPLE_NAME
+          value: {{ $tests.upload.sampleFileName | quote }}
+        - name: SAMPLE_PATH
+          value: {{ $samplePath | quote }}
+        - name: EXPECT_PARSER_NAME
+          value: {{ $tests.upload.expectParserName | quote }}
+        - name: EXPECT_ENTRY_TYPE
+          value: {{ $tests.upload.expectEntryType | quote }}
+        {{- if and $tests.upload.enabled $tests.upload.credentialsSecret }}
+        # Keys are optional: supply `token` (a pre-created NOMAD app token) OR
+        # `username`+`password`. Missing keys are fine thanks to optional: true.
+        - name: NOMAD_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ $tests.upload.credentialsSecret | quote }}
+              key: token
+              optional: true
+        - name: NOMAD_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: {{ $tests.upload.credentialsSecret | quote }}
+              key: username
+              optional: true
+        - name: NOMAD_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ $tests.upload.credentialsSecret | quote }}
+              key: password
+              optional: true
+        {{- end }}
+      volumeMounts:
+        - name: test-scripts
+          mountPath: /scripts
+        {{- if $extSample }}
+        - name: test-sample
+          mountPath: /sample
+          readOnly: true
+        {{- end }}
+  volumes:
+    - name: test-scripts
+      configMap:
+        name: {{ include "nomad.fullname" . }}-test
+    {{- if $extSample }}
+    - name: test-sample
+      {{- if $tests.upload.existingSampleSecret }}
+      secret:
+        secretName: {{ $tests.upload.existingSampleSecret | quote }}
+      {{- else }}
+      configMap:
+        name: {{ $tests.upload.existingSampleConfigMap | quote }}
+      {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/default/values.yaml
+++ b/charts/default/values.yaml
@@ -479,6 +479,78 @@ nomad:
       successThreshold: 1
       timeoutSeconds: 1
 
+  # `helm test <release>` smoke test that verifies the data pipeline actually
+  # works end-to-end, beyond pods merely being "Ready". Two tiers:
+  #   Tier 1 (always, no credentials): hits the API through the proxy and asserts
+  #     Elasticsearch responds and that the plugin entry points named in `expect`
+  #     (parsers, normalizers, apps, apis, dashboards) are loaded/mounted — proving
+  #     your custom image's plugins registered.
+  #   Tier 2 (opt-in, needs credentials): logs in, uploads a file, waits for it to
+  #     finish, and asserts process_status==SUCCESS with entries created, searchable,
+  #     and produced by the expected parser (proves app -> Temporal -> worker ->
+  #     Mongo -> shared fs volumes), then deletes it. Also checks `expect.actions`,
+  #     which the API only exposes to a logged-in user.
+  tests:
+    # Disabled by default: opt in per deployment. When true, `helm test <release>`
+    # renders and runs the verification hook described above.
+    enabled: false
+    # Override the test image; defaults to nomad.image (already present in-cluster,
+    # ships python3 — no extra pull).
+    image: {}
+    # Per-plugin-type presence checks. Each list names entry points that MUST be
+    # loaded/mounted; empty = skip that type. This proves a plugin's entry point
+    # actually registered (not just that the package is on disk). All run in Tier 1
+    # (no credentials) EXCEPT `actions`, which the API only exposes to a logged-in
+    # user — those are checked in Tier 2 when upload credentials are provided.
+    expect:
+      parsers: []          # names from GET /info parsers[]        e.g. "parsers/vasp"
+      normalizers: []      # names from GET /info normalizers[]
+      pluginPackages: []   # names from GET /info plugin_packages[] (any type, package-level)
+      apps: []             # app id or path from GET /api/v1/apps/entry-points
+      apis: []             # API entry point prefixes (mounted FastAPI at <base>/<prefix>)
+      dashboards: []       # dashboard id_url_safe (mounted at <base>/dashboards/<id>)
+      actions: []          # action_id from GET /api/v1/actions/schemas (needs credentials)
+    upload:
+      # Off by default: the full upload flow needs a real user to authenticate
+      # against the configured Keycloak.
+      enabled: false
+      # Name of a Secret holding NOMAD credentials. Provide EITHER:
+      #   - key `token`: a pre-created NOMAD app token (recommended; portable,
+      #     works even where the Keycloak realm disables the password grant), OR
+      #   - keys `username` + `password`: a NOMAD account (ROPC login).
+      credentialsSecret: ""
+      # Seconds to wait for processing (and for cleanup) before failing.
+      timeout: 300
+      # Name of the file that gets uploaded. NOMAD auto-extracts .zip/.tar, so a
+      # zipped directory of raw files works out of the box (one entry per mainfile).
+      sampleFileName: test.archive.json
+      # Inline sample content (text only). Minimal archive that parses to a valid
+      # empty entry on any distro. Ignored when existingSampleConfigMap/Secret is
+      # set (use those for binary samples like .zip — see below).
+      sampleFileContent: |
+        {
+          "metadata": {
+            "entry_name": "nomad-helm-test",
+            "comment": "NOMAD Helm chart helm-test smoke entry"
+          }
+        }
+      # For a local .zip (or any binary) sample: create a ConfigMap/Secret from it
+      # once, then reference it here. The key inside MUST equal sampleFileName, and
+      # sampleFileName should carry the right extension (e.g. sample.zip):
+      #   kubectl create configmap nomad-test-sample \
+      #     --from-file=sample.zip=./sample.zip -n <namespace>
+      # then set sampleFileName: sample.zip and existingSampleConfigMap: nomad-test-sample.
+      # Note: ConfigMaps/Secrets cap at ~1 MiB; for larger fixtures use a PVC.
+      # Use a Secret instead when the sample is sensitive (takes precedence).
+      existingSampleConfigMap: ""
+      existingSampleSecret: ""
+      # Prove a CUSTOM plugin actually ran (not just registered): after processing,
+      # assert the entry was produced by this parser rather than parsers/archive.
+      # Pair with a sampleFileContent your parser matches. Empty = skip.
+      expectParserName: ""
+      # Optionally assert the resulting entry's schema/entry_type. Empty = skip.
+      expectEntryType: ""
+
   ingress:
     enabled: false
     limitConnections: 32


### PR DESCRIPTION
This pull request introduces a comprehensive Helm test suite for the NOMAD deployment, designed to verify not just pod readiness but also actual data flow through the application's pipeline, including custom plugins. The documentation has been significantly expanded to explain how to enable and configure these tests, and user-facing notes have been updated to highlight their use.

**Helm test suite and documentation improvements:**

* Added a detailed section to `README.md` explaining the new `helm test` hook, its configuration (`nomad.tests`), plugin-type coverage, authentication, and usage in CI/CD pipelines. This includes guidance for verifying custom plugins and uploading test files, with configuration examples.
* Updated `templates/NOTES.txt` to display instructions for running `helm test` when enabled, emphasizing its ability to verify plugin loading and full pipeline execution.
